### PR TITLE
fix: Face normals now point outward correctly instead of inward

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jscad-electronics",
   "type": "module",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "main": "./dist/index.js",
   "exports": {
     ".": {


### PR DESCRIPTION
Changed: `cross(ab, ac) → cross(ac, ab)` in the normal calculation
Result: Face normals now point outward correctly instead of inward
fix #4